### PR TITLE
node-sass workarounds

### DIFF
--- a/lib-core/sass/core/_direct-apply.sass
+++ b/lib-core/sass/core/_direct-apply.sass
@@ -189,7 +189,7 @@ form
   &:before
     border-top-color: $color
 
-=tooltip-classes
+// =tooltip-classes
 
 [data-ks-tooltip]
   position: relative

--- a/lib-core/sass/themes/default/theme.sass
+++ b/lib-core/sass/themes/default/theme.sass
@@ -22,7 +22,7 @@ $black: (lightest: #444, lighter: #333, light: #222)
 $colors: (red: #CA3518, orange: darkorange, yellow: #ffe312, green: #58AA00, blue: #47A5DF, violet: darkmagenta)
 
 // Vendor libraries
-@import url(//fonts.googleapis.com/css?family=Lato:300,400,700,400italic)
+@import url(https://fonts.googleapis.com/css?family=Lato:300,400,700,400italic)
 
 // Ten point design variables
 // --------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kickstart-node",
-  "version": "3.0.76",
+  "version": "3.0.77",
   "description": "A front-end library for clean HTML and fast performance",
   "keywords": [
     "CoffeeScript",


### PR DESCRIPTION
1. The current release of node-sass doesn't support urls without a schema. Using https should always work and it required if accessing the HTML using a file:// url.
2. node-sass complained about the syntax of a line containing tooltip-classes, but I wasn't sure what it's purpose was, since it looks like an empty mixin.
