### PR TITLE
Main _kickstart.sass file for use in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
   ],
   "description": "The CSS Library that Loves to Be Extended",
   "license": "MIT",
+  "main": ["lib-core/sass/_kickstart.sass"],
   "ignore": [
     "**/.*",
     "node_modules",

--- a/lib-core/sass/_kickstart.sass
+++ b/lib-core/sass/_kickstart.sass
@@ -1,0 +1,9 @@
+@import core/_base
+@import core/_base_components
+@import core/_dependent_components
+@import core/_icons
+@import core/_mixins
+@import core/_animations
+@import core/_grid
+@import core/_typography
+@import core/_root-element


### PR DESCRIPTION
Created _kickstart.sass in lib-core to bring all core partials together for bower users. Added main to bower.json to point to this file
