### PR TITLE
Clicking an open dropdown should close the dropdown

### DIFF
--- a/gulp/tasks/docs/jade.js
+++ b/gulp/tasks/docs/jade.js
@@ -11,7 +11,7 @@ gulp.task('docs:jade', function() {
     .pipe(changed(dest))
     .pipe(jade({
         locals: {
-          currentVersion: '3.1 beta',
+          currentVersion: '3.2 beta',
           docsVersion: '3.x',
           nextDocsVersion: '4.x',
           fs: fs,

--- a/lib-core/coffee/dropdown.coffee
+++ b/lib-core/coffee/dropdown.coffee
@@ -1,68 +1,11 @@
 dropdown = () ->
 
   document.body.addEventListener 'click', (e) ->
-    $menuItem = null
-
-    closeAllMenus = ->
-      _$menuItem.classList.remove 'open' for _$menuItem in k$.$$('.menu-item')
-
-    # We'll need this later.
-    openMenu = ->
-      # User has clicked on a menu trigger.
-      if $menuItem.classList.contains 'open' 
-        $menuItem.classList.remove 'open' 
-      else 
-        closeAllMenus() 
-        $menuItem.classList.add 'open'
-      e.stopPropagation()
-
-    # Let's check if a user has clicked on a menu trigger:
-    if e.target.classList.contains 'menu-item'
-      $menuItem = e.target 
-      openMenu()
-    else if e.target.parentNode.classList.contains 'menu-item'
-      $menuItem = e.target.parentNode
-      openMenu()
-    else
-      closeAllMenus()
-      return
-
-
-
-  # # The following should apply to several elements.
-  #
-  # $menuItems = k$.$$ '.menu-item'
-  #
-  # for $_menuItem in $menuItems
-  #
-  #   $menuItem = $_menuItem.cloneNode true
-  #   $_menuItem.parentNode.replaceChild $menuItem, $_menuItem
-  #
-  #   do ($menuItem) ->
-
-      # TODO make only one event listener for the parent.
-      # $menuItem.addEventListener 'click', (e) ->
-
-        # # Just close it if it's already open
-        # if $menuItem.classList.contains 'open'
-        #   $menuItem.classList.remove 'open'
-        #   return
-        #
-        # # Reset all
-        # _$menuItem.classList.remove 'open' for _$menuItem in document.querySelectorAll('.menu-item')
-        # $openable = $menuItem.querySelector 'ul'
-        #
-        # # Open this one
-        # if $openable
-        #   $menuItem.classList.add 'open'
-        #
-        # # Prevent bubbling
-        # e.stopPropagation()
-
-  # # Dismiss all
-  # document.body.addEventListener 'click', ->
-  #   $ul.parentNode.classList.remove 'open' for $ul in k$.$$('.menu-item > ul')
-  #   $li.classList.remove 'open' for $li in k$.$$('.menu-item.open')
+    if e.target.classList.contains('menu-item') && ! e.target.classList.contains('open')
+      e.target.classList.add 'open'
+      document.addEventListener('click', dismiss = ->
+        e.target.classList.remove 'open'
+        document.removeEventListener 'click', dismiss
 
 k$.dropdown = dropdown
 

--- a/lib-core/sass/core/_direct-apply.sass
+++ b/lib-core/sass/core/_direct-apply.sass
@@ -159,7 +159,6 @@ form
   left: 50%
   margin-left: -20px
   box-shadow: 0px 5px 25px rgba(0, 0, 0, 0.25)
-  pointer-events: none
   min-width: 100px
   text-align: center
   pointer-events: none

--- a/lib-docs/jade/about/index.jade
+++ b/lib-docs/jade/about/index.jade
@@ -33,9 +33,6 @@ block content
       - Have only one or a few themes. Who wants a framework that makes your site look like
         everyone else's?
 
-      Extensibility is a #1, unfulfilled need in the world of frameworks.  Kickstart is solving this
-      with its own native solution, the [Kickstart Store](http://kickstart.everything.io).
-
       ## Why aren't your docs accessible
 
       When I wrote the docs, I assumed I would get backlash for not writing `aria-this` and `aria-that`

--- a/lib-docs/jade/docs/3.x/_layout.jade
+++ b/lib-docs/jade/docs/3.x/_layout.jade
@@ -1,7 +1,7 @@
 extends ../../3.x-layouts/_layout
 
 block menuVars
-  - var menuItem = "docs" 
+  - var menuItem = "docs"
 
 block page-stylesheet
   block ui-stylesheet
@@ -9,7 +9,7 @@ block page-stylesheet
   link(rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/solarized_dark.min.css")
   link(rel="stylesheet" href="/css/pages/docs/index.min.css")
   script.
-    hljs.initHighlightingOnLoad(); 
+    hljs.initHighlightingOnLoad();
 
 block bleed
   header.doc-hero
@@ -29,6 +29,9 @@ block content
     //- Fixed sidebar
     aside.fixed-toc
       h1 #{title}
+      <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+      <ins class="adsbygoogle" style="display:inline-block;width:300px;height:250px" data-ad-client="ca-pub-8803544022324306" data-ad-slot="8378683878"></ins>
+      <script> (adsbygoogle = window.adsbygoogle || []).push({}); </script>
       form.switches
         .form_group
           .switch(data-ks-tooltip="Turn on if you're using the Sass mixins" data-ks-tooltip-color="green")

--- a/lib-docs/jade/docs/3.x/adding-extensions/index.jade
+++ b/lib-docs/jade/docs/3.x/adding-extensions/index.jade
@@ -34,7 +34,7 @@ block documents
       :markdown
         ## Adding submodules
 
-        On the [Kickstart Store](http://kickstart.everything.io), each extension has a submodule creation
+        Each extension has a submodule creation
         command that should look something like the code you see here.
 
         Running this in the terminal will create a folder (in this case "switch") and will download the

--- a/lib-docs/jade/docs/3.x/ui/icons-hidden/index.jade
+++ b/lib-docs/jade/docs/3.x/ui/icons-hidden/index.jade
@@ -46,8 +46,7 @@ block documents
 
         Icons come in the fidelities Small, Regular, and Large.
 
-        To use the individual SVG files, download them from the Kickstart Store or via
-        the button above.
+        To use the individual SVG files, download them from the button above.
 
       p
         img.icon(src="/svgs/rg/foo.svg")
@@ -62,7 +61,7 @@ block documents
 
   .document
     article.article
-      :markdown 
+      :markdown
         ### Method 2: Use a "sprite"
 
         Img tags aren't ideal when using multiple icons on a page because it adds to the number
@@ -96,7 +95,7 @@ block documents
       :markdown
         ## Use responsive icons
 
-        Responsive icons vary in level of fidelity based on the width of the screen. There are several 
+        Responsive icons vary in level of fidelity based on the width of the screen. There are several
         ways to load these. All of which work with IE, Chrome, Firefox, and Safari and preserve cacheability.
 
   .document
@@ -140,7 +139,7 @@ block documents
 
   .document
     article.article
-      :markdown 
+      :markdown
         #### Method 2: Use a "sprite"
 
         This method is identical to what we did with the single fidelity icon above, however

--- a/lib-docs/jade/docs/4.x/advanced/adding-extensions/index.jade
+++ b/lib-docs/jade/docs/4.x/advanced/adding-extensions/index.jade
@@ -37,7 +37,7 @@ block documents
       :markdown
         ## Adding submodules
 
-        On the [Kickstart Store](http://kickstart.everything.io), each extension has a submodule creation
+        Each extension has a submodule creation
         command that should look something like the code you see here.
 
         Running this in the terminal will create a folder (in this case "switch") and will download the

--- a/lib-docs/jade/docs/4.x/index.jade
+++ b/lib-docs/jade/docs/4.x/index.jade
@@ -1,20 +1,25 @@
 extends _layout
 
 block hero-title
-  h1 Quickstart
+  h1 1. Quickstart
 
 block variables
   - var showFooter = false
-  - var title = 'Quickstart'
+  - var title = '1. Quickstart'
 
 block subMenuVars
   - var subMenuItem = "getstarted"
 
 block documents
-  include ../3.x/_includes/quickstart/_quickstart_header.jade
+  .document
+    article.article.article-full
+      :markdown
+        # 1. Quickstart
+
+        Installation instructions are available for [Simple HTML](#barebones), [Rails](#rails), and [Gulp](#gulp).
   .document
     article.article
-      h1 Barebones
+      h1 1A. Barebones
       h2 Head code
 
       :markdown
@@ -106,7 +111,7 @@ block documents
 
   .document
     article.article
-      h1 Rails
+      h1 1B. Rails
 
       :markdown
         Install the [Kickstart gem](https://rubygems.org/gems/kickstart_rails)
@@ -200,7 +205,7 @@ block documents
 
   .document
     article.article
-      h1 Gulp
+      h1 1C. Gulp
 
       :markdown
         My tool of choice for building all of Kickstart is gulp, plus a ton of
@@ -221,7 +226,7 @@ block documents
       :markdown
         <span>
 
-            $(~) git clone git@github.com:adamjgrant/kickstart.git mywebsite --depth 1
+            $(~) git clone git@github.com:adamjgrant/kickstart.git mywebsite
 
             # Install the dependencies
             $(~) cd mywebsite
@@ -229,49 +234,3 @@ block documents
 
             # If all goes well, this should launch your project.
             $(mywebsite) gulp
-
-
-  include ../3.x/_includes/quickstart/_jekyll.jade
-
-  .document
-    article.article
-      h1 Node.js
-
-      :markdown
-        Kickstart can easily be added as an npm package.
-        This will download the entire repo to a `node_modules` folder.
-
-    article.code
-      :markdown
-        <span>
-
-            npm install --save-dev kickstart-node
-
-  .document
-    article.article
-      :markdown
-        In your sass or scss file, import Kickstart via the theme you prefer:
-
-        Notice you may need a couple `../`s before `node_modules` to point
-        to the node_modules directory. This all depends on how you organized your
-        project.
-
-        In the example, node_modules is at the same level as the scss/sass
-        file.
-
-    article.code
-      :markdown
-        <span>
-
-            @import node_modules/kickstart-node/lib/sass/themes/default/theme
-
-  .document
-    article.article.article-full
-      :markdown
-        ## Autoprefixer
-
-        The chances are very good that you'll need to include [autoprefixer](https://github.com/postcss/autoprefixer).
-        This will add prefixes like `-webkit-` to bleeding edge css properties. Make sure
-        this is included as part of your CSS compilation workflow.
-
-        [Also available for Gulp](https://www.npmjs.org/package/gulp-autoprefixer)

--- a/lib-docs/jade/docs/4.x/tutorial/layout/index.jade
+++ b/lib-docs/jade/docs/4.x/tutorial/layout/index.jade
@@ -1,0 +1,169 @@
+extends ../../_layout
+
+block hero-title
+  h1 2. Layout
+
+block variables
+  - var showFooter = false
+  - var title = '2. Layout'
+
+block subMenuVars
+  - var subMenuItem = "getstarted"
+
+block documents
+  .document
+    article.article.article-full
+      :markdown
+        # 2. Laying out the page
+
+        Now that you have some basic HTML properties in place, let's get the
+        content "wrapped" up.
+
+        Kickstart includes some simple and effective defaults for keeping proper
+        spacing and expansion on the body of the page. These work seamlessly with
+        grid tools as well.
+
+  .document
+    article.article
+      h1 Wrapper
+
+    article.code
+      :markdown
+        <span>
+
+            <div class="wrapper">
+              <h1>My page</h1>
+              <p>Welcome to my page</p>
+            </div>
+
+            .wrapper {
+              @include wrapper();
+            }
+  .document
+    article.article.article-full
+      :markdown
+        # Wrapper styles
+
+        Before you start adding components to your page, it's best to decide if
+        you want a fixed, fluid, or fixed-fluid layout.
+
+        ## Fixed layout
+
+        A fixed layout simply limits the width of the layout to a certain amount.
+
+      iframe.animation(scrolling="no" src="/iframes/layout-fixed/fixed.html")
+
+  .document
+    article.article
+      .if-semantic
+        :markdown
+          For a fixed wrapper, create a fluid wrapper around your content with `$fluid; true`.
+            Now you just need to limit that fluidity with a max-width property.
+
+      .ifnot-semantic
+        :markdown
+          For a fixed wrapper, use the `.wrapper.wrapper-fixed` classes.
+      :markdown
+        The default max-width is about 768px, however, you can define your own by adding
+        a `max-width` property.
+
+    article.code
+      .if-semantic
+        :markdown
+          <span>
+
+              <div class="wrapper">
+                <h1>Hello world</h1>
+              </div>
+
+              .wrapper{
+                @include wrapper($fluid: true);
+                max-width: 700px;
+              }
+
+      .ifnot-semantic
+        :markdown
+          <span>
+
+              <div class="wrapper wrapper-fixed">
+                <h1>Hello world</h1>
+              </div>
+
+              .wrapper.wrapper-fixed {
+                max-width: 700px; // if 768px is not sufficient
+              }
+
+  .document
+    article.article
+      :markdown
+        ## Fluid layout
+
+        A fluid layout allows the width of the content to match the width of the viewport
+
+      iframe.animation(scrolling="no" src="/iframes/layout-fluid/fluid.html")
+
+      :markdown
+        For a fluid wrapper <span class="if-semantic"> use the mixin
+        <code>wrapper($fluid: true)</code></span>
+
+        To have elements break out of a wrapper (called "bleeding"), just
+        end the wrapper before the bleed content and open it back up afterwards.
+
+    article.code
+      .if-semantic
+        :markdown
+          <span>
+
+              .wrapper {
+                @include wrapper($fluid: true);
+              }
+
+      .ifnot-semantic
+        :markdown
+          <span>
+
+              <div class="wrapper wrapper-fluid">
+                ...
+              </div>
+
+  .document
+    article.article.article-full
+      :markdown
+        ## Fluid-fixed layout
+
+        This layout is the default behavior for a wrapper in Kickstart and
+        combines the best of both worlds.
+
+        Instead of constantly resizing to the size of the viewport, a new fixed
+        width is used at each breakpoint.
+
+      iframe.animation(scrolling="no" src="/iframes/layout-fluid-fixed/fluid-fixed.html")
+
+  .document
+    article.article
+      :markdown
+        Create a wrapper around your content <span class="if-semantic">and use the mixin
+        <code>wrapper()</code></span><span class="ifnot-semantic">and
+        use the <code>.wrapper</code> class.
+
+    article.code
+      .if-semantic
+        :markdown
+          <span>
+
+              <div class="wrapper">
+                <h1>Hello world</h1>
+              </div>
+
+              .wrapper{
+                @include wrapper();
+              }
+
+      .ifnot-semantic
+        :markdown
+          <span>
+
+              <div class="wrapper">
+                <h1>Hello world</h1>
+              </div>
+

--- a/lib-docs/jade/docs/4.x/ui/components/icons-hidden/index.jade
+++ b/lib-docs/jade/docs/4.x/ui/components/icons-hidden/index.jade
@@ -46,8 +46,7 @@ block documents
 
         Icons come in the fidelities Small, Regular, and Large.
 
-        To use the individual SVG files, download them from the Kickstart Store or via
-        the button above.
+        To use the individual SVG files, download them via the button above.
 
       p
         img.icon(src="/svgs/rg/foo.svg")

--- a/lib-docs/jade/index.jade
+++ b/lib-docs/jade/index.jade
@@ -402,7 +402,7 @@ block content
             p 1 passing (9ms)
 
       div(data-component="step")
-        h2 Kickstart has a lot of components, but it's also extendible. So we can add third party UIs from the community in the Kickstart Store.
+        h2 Kickstart has a lot of components, but it's also extendible. 
 
         .code
           h3 Terminal

--- a/lib-docs/jade/index.jade
+++ b/lib-docs/jade/index.jade
@@ -615,9 +615,7 @@ block content
 
         h1 Loves to be extended
         p
-          | The library is just the core. Kickstart is designed to be extended and themed via the&nbsp;
-          a(href="http://kickstart.everything.io") Kickstart Store
-          | .
+          | The library is just the core. Kickstart is designed to be extended and themed.
 
   article.home-wrapper
     section.use-in-any-project

--- a/lib-docs/sass/docs.sass
+++ b/lib-docs/sass/docs.sass
@@ -141,3 +141,21 @@ svg.icon
 
 .switch
   +switch
+
+.adsbygoogle
+
+  @media screen and (max-width: #{$phablet + 1})
+    margin: 0px auto !important
+    display: block !important
+
+  @media screen and (min-width: #{$phablet}) and (max-width: #{$tablet+1})
+    margin-left: -25px !important
+
+  @media screen and (min-width: #{$tablet}) and (max-width: #{$desktop+1})
+    display: none !important
+
+  @media screen and (min-width: #{$desktop})
+    margin-left: -10px !important
+
+  iframe
+    padding: 0

--- a/lib-docs/sass/pages/docs/index.sass
+++ b/lib-docs/sass/pages/docs/index.sass
@@ -11,7 +11,7 @@ h2
   +heading-xs
 
 h3, h4, h5, h6
-  +heading-xxs 
+  +heading-xxs
 
 .alert
   +alert
@@ -62,9 +62,9 @@ h3, h4, h5, h6
 
     @media screen and (min-width: $tablet)
       width: 75%
-
-    @media screen and (min-width: $large-monitor)
-      width: 80%
+    //
+    // @media screen and (min-width: $large-monitor)
+    //   width: 80%
 
   .fixed-toc
     width: 100%
@@ -105,7 +105,7 @@ h3, h4, h5, h6
         bottom: 0
 
       > li
-        margin-bottom: 0 
+        margin-bottom: 0
 
         a
           font-weight: bold
@@ -167,7 +167,7 @@ h3, h4, h5, h6
                             margin-bottom: 0
 
     h1
-      +heading-xs 
+      +heading-xs
 
     @media screen and(min-width: $phablet)
       padding: $space
@@ -176,12 +176,12 @@ h3, h4, h5, h6
     @media screen and (min-width: $tablet)
       width: 25%
 
-    @media screen and (min-width: $large-monitor)
-      width: 20%
+    // @media screen and (min-width: $large-monitor)
+    //   width: 20%
 
   // When in fixed position
   body.fixed-nav &
-    .fixed-toc 
+    .fixed-toc
       @media screen and (min-width: $phablet)
         position: fixed
         top: 0px
@@ -194,7 +194,7 @@ h3, h4, h5, h6
         right: 75%
 
       @media screen and (min-width: $large-monitor)
-        right: 80% 
+        right: 80%
 
       @media screen and (min-width: $xl-monitor)
         left: calc(50vw - #{$xl-monitor/2})
@@ -212,8 +212,8 @@ h3, h4, h5, h6
       @media screen and (min-width: $tablet)
         margin-left: 25%
 
-      @media screen and (min-width: $large-monitor)
-        margin-left: 20%
+      // @media screen and (min-width: $large-monitor)
+      //   margin-left: 20%
 
 .document
   margin-bottom: $space * 4
@@ -340,7 +340,7 @@ body.show-semantic
 
   span.if-semantic
     display: inline
-    
+
 body.show-jquery
   .ifnot-jquery
     display: none

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "gulp-jade": "^0.6.1",
     "gulp-minify-css": "^0.3.8",
     "gulp-mocha": "^1.0.0",
-    "gulp-mocha-phantomjs": "^0.8.1",
+    "gulp-mocha-phantomjs": "^0.10.1",
     "gulp-mustache": "^0.4.0",
     "gulp-newer": "^0.3.0",
     "gulp-notify": "^1.5.0",


### PR DESCRIPTION
I'm not clear on why the code opened the parent .menu-item of any clicked element.

It seems that the only way the element could have been clicked in the first place is if its parent .menu-item was already open. So either that code was pointless, or I have failed to understand some case that this PR will now break.

Either way, when you click on an open dropdown, this PR should close that dropdown.

This assumes that EventListeners for the same event on the same element are executed in the order in which they were added.
